### PR TITLE
Add missing repository files (LICENSE, CONTRIBUTING, CODE_OF_CONDUCT)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Resources:
+
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to LangChain for Beginners
+
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## How to Contribute
+
+We welcome contributions to this course! Here are some ways you can help:
+
+### Reporting Issues
+
+- Check if the issue already exists before creating a new one
+- Provide detailed information about the problem
+- Include steps to reproduce the issue
+- Share your environment details (OS, Node.js version, etc.)
+
+### Suggesting Enhancements
+
+- Clearly describe the enhancement and its benefits
+- Explain why this would be useful to most users
+- Provide examples if possible
+
+### Pull Requests
+
+1. Fork the repository
+2. Create a new branch for your feature or fix
+3. Make your changes
+4. Test your changes thoroughly
+5. Submit a pull request with a clear description of the changes
+
+### Code Style
+
+- Follow the existing code style and conventions
+- Use meaningful variable and function names
+- Add comments for complex logic
+- Ensure your code is properly formatted
+
+### Documentation
+
+- Keep documentation up to date with code changes
+- Use clear and concise language
+- Include code examples where appropriate
+- Check for spelling and grammar errors
+
+Thank you for contributing to LangChain for Beginners!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE


### PR DESCRIPTION
This PR adds the essential repository files that are referenced by the shields/badges in the README:

- **LICENSE** - MIT License file
- **CONTRIBUTING.md** - Contribution guidelines
- **CODE_OF_CONDUCT.md** - Microsoft Open Source Code of Conduct

These files are required for the GitHub badges to work properly and provide important information for contributors.